### PR TITLE
fixed error #39 - buttons in mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
             <small class="pull-right">Grade Average : <span class="avgGrade label label-default"></span></small>
         </h3>
     </div>
-    <div class="student-add-form col-md-3 pull-right">
+    <div class="student-add-form form-group col-md-3 col-md-push-9 col-sm-3 col-sm-push-9 col-lg-3 col-lg-push-9">
         <h4>Add Student</h4>
         <div class="input-group form-group">
             <span class="input-group-addon">
@@ -45,7 +45,7 @@
         <button type="button" class="btn btn-success" onclick="controller.addClicked();">Add</button>
         <button type="button" class="btn btn-default" onclick="controller.cancelClicked();">Cancel</button>
     </div>
-    <div class="student-list-container col-md-9">
+    <div class="student-list-container col-md-9 col-md-pull-3 col-sm-9 col-sm-pull-3 col-lg-9 col-lg-pull-3">
         <table class="student-list table">
             <thead>
             <tr>

--- a/script.js
+++ b/script.js
@@ -16,6 +16,8 @@ var input = "";
 $(document).ready(function () {
     controller.reset();
     $("")
+
+
 });
 
 var controller = new Controller();

--- a/style.css
+++ b/style.css
@@ -23,3 +23,6 @@ tr {
     cursor: pointer;
 }
 
+button {
+    cursor: pointer;
+}


### PR DESCRIPTION
The "pull-right" class made the student list container overlap the student form in xsmall screens, covering the buttons. I replaced the "pull-right" class with bootstrap's column ordering classes.
